### PR TITLE
Create codemeta.json

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -1,0 +1,68 @@
+{
+  "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
+  "@type": "SoftwareSourceCode",
+  "identifier": "796699799",
+  "name": "Software Metadata Extraction and Curation Software (SMECS)",
+  "description": "SMECS is a web-based tool designed to extract and curate research software metadata in alignment with the codemeta software metadata standard. By accessing repositories on platforms like GitHub and GitLab, SMECS extracts multiple already existing metadata in the harvesting phase. In the curation phase its intuitive graphical interface allows researchers to easily improve and change the retrieved metadata to bestly represent their software. Ultimately, SMECS allows to export the curated metadata in JSON format in line with the codemeta stand.",
+  "codeRepository": "https://github.com/NFDI4Energy/SMECS",
+  "issueTracker": "https://github.com/NFDI4Energy/SMECS/issues",
+  "license": "https://spdx.org/licenses/AGPL-3.0",
+  "contributor": [
+    {
+        "id": "_:contributor_1",
+        "type": "Person",
+        "email": "stephan.ferenz@uol.de",
+        "familyName": "Ferenz",
+        "givenName": "Stephan"
+    },
+    {
+        "id": "_:contributor_2",
+        "type": "Person",
+        "email": "aida.jafarbigloo.274@gmail.com",
+        "familyName": "Jafarbigloo",
+        "givenName": "Aida"
+    },
+    {
+        "id": "_:contributor_3",
+        "type": "Person",
+        "email": "sundraiz.shah@gmail.com",
+        "familyName": "Sundraiz Shah",
+        "givenName": "Syed"
+    }
+  ],
+  "author": [
+    {
+        "id": "_:author_1",
+        "type": "Person",
+        "email": "stephan.ferenz@uol.de",
+        "familyName": "Ferenz",
+        "givenName": "Stephan"
+    },
+    {
+        "id": "_:author_2",
+        "type": "Person",
+        "email": "aida.jafarbigloo.274@gmail.com",
+        "familyName": "Jafarbigloo",
+        "givenName": "Aida"
+    }
+  ],
+  "programmingLanguage": [
+    "Python",
+    "HTML",
+    "CSS",
+    "JavaScript",
+    "Dockerfile",
+    "Shell"
+  ],
+  "keywords": [
+    "software metadata",
+    "extraction",
+    "curation",
+    "repository",
+    "research software",
+    "codemeta"
+  ],
+  "dateCreated": "2024-05-06",
+  "downloadUrl": "https://github.com/NFDI4Energy/SMECS/releases",
+  "citation": "Ferenz, S., & Jafarbigloo, A. Software Metadata Extraction and Curation Software (SMECS) [Computer software]. https://github.com/NFDI4Energy/SMECS"
+}  


### PR DESCRIPTION
Add codemeta.json for testing HERMES when harvesting metadata from a provided URL not the local path.

(If harvesting metadata locally from codemeta.json via HERMES, remove the similar file in static directory in SMECS repository.)