### PR TITLE
Differentiate between URL and token errors (#209)

### DIFF
--- a/meta_creator/token_check.py
+++ b/meta_creator/token_check.py
@@ -1,3 +1,5 @@
+from .url_check_GitHub import validate_github_inputs
+from .url_check_GitLab import validate_gitlab_inputs
 import requests
 import json
 import os
@@ -113,4 +115,23 @@ def validate_token(repo_url, token):
             return fallback_token  # Valid fallback token
         return None  # Not okay for GitLab
 
-    return None  
+    return None
+
+
+def validate_repo_and_token(repo_url, token):
+    if is_github_repo(repo_url):
+        is_valid_url, url_error = validate_github_inputs(repo_url)
+        if not is_valid_url:
+            return False, f"URL error: {url_error}"
+        if token and not check_github_token(repo_url, token):
+            return False, "Token error: Invalid GitHub token"
+        return True, "GitHub repository and token are valid"
+
+    elif "gitlab.com" in repo_url:
+        is_valid_url, error = validate_gitlab_inputs(repo_url, token)
+        if not is_valid_url:
+            return False, f"Validation failed: {error}"
+        return True, "GitLab repository and token are valid"
+
+    # Fallback for malformed or unrecognized URLs
+    return False, "URL error: Repository host must be GitHub or GitLab"

--- a/meta_creator/token_check.py
+++ b/meta_creator/token_check.py
@@ -119,19 +119,38 @@ def validate_token(repo_url, token):
 
 
 def validate_repo_and_token(repo_url, token):
+    """
+    Validates both the repository URL and the API token.
+
+    This function will first check whether the repository host is supported (GitHub or GitLab),
+    then validates the repository URL for proper formatting and existence.
+    If the URL is valid, it proceeds to validate the API token if one is provided.
+
+    Args:
+        repo_url (str): The full URL of the repository.
+        token (str): The access token used for API authentication.
+
+    Returns:
+        tuple: A tuple containing a bool (True if both URL and token are valid; otherwise False.),
+        and a str (A message indicating which validation step failed or if validation succeeded.)
+    """
+
+    # Handle GitHub validation
     if is_github_repo(repo_url):
         is_valid_url, url_error = validate_github_inputs(repo_url)
         if not is_valid_url:
             return False, f"URL error: {url_error}"
+        # Only check token if provided
         if token and not check_github_token(repo_url, token):
             return False, "Token error: Invalid GitHub token"
         return True, "GitHub repository and token are valid"
 
+    # Handle GitLab validation
     elif "gitlab.com" in repo_url:
         is_valid_url, error = validate_gitlab_inputs(repo_url, token)
         if not is_valid_url:
             return False, f"Validation failed: {error}"
         return True, "GitLab repository and token are valid"
 
-    # Fallback for malformed or unrecognized URLs
+    # Handle unknown or unsupported repository host
     return False, "URL error: Repository host must be GitHub or GitLab"

--- a/tests/test_token_check.py
+++ b/tests/test_token_check.py
@@ -1,0 +1,46 @@
+import unittest
+from meta_creator.token_check import validate_repo_and_token
+
+
+class TestTokenValidation(unittest.TestCase):
+
+    def test_invalid_github_url(self):
+        url = "https://github.com/invalid_user/invalid_repo"
+        token = "ghp_invalidToken111"
+        success, message = validate_repo_and_token(url, token)
+        self.assertFalse(success)
+        self.assertIn("URL error", message)
+
+    def test_invalid_token_valid_url(self):
+        url = "https://github.com/NFDI4Energy/SMECS"
+        token = "ghp_invalidToken222"
+        success, message = validate_repo_and_token(url, token)
+        self.assertFalse(success)
+        self.assertIn("Token error", message)
+
+    def test_malformed_url(self):
+        url = "no_url"
+        token = "ghp_invalidToken333"
+        success, message = validate_repo_and_token(url, token)
+        self.assertFalse(success)
+        self.assertIn("URL error", message)
+
+    def test_unknown_host(self):
+        url = "https://bitbucket.org/user/repo"
+        token = "ghp_invalidToken444"
+        success, message = validate_repo_and_token(url, token)
+        self.assertFalse(success)
+        self.assertIn("URL error", message)
+
+    @unittest.skip("Requires real GitHub token")
+    def test_valid_github_token(self):
+        url = "https://github.com/octocat/Hello-World"
+        token = "ghp_yourValidTokenHere"
+        success, message = validate_repo_and_token(url, token)
+        self.assertTrue(success)
+        self.assertIn("valid", message.lower())
+
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/tests/test_token_check.py
+++ b/tests/test_token_check.py
@@ -1,6 +1,21 @@
 import unittest
 from meta_creator.token_check import validate_repo_and_token
 
+"""
+This module contains unit tests for validating the behavior of the
+`validate_repo_and_token` function, which checks the repository URLs and
+the access tokens for GitHub and GitLab.
+
+The tests cover common error cases such as:
+- Invalid repository URLs
+- Invalid tokens
+- Unsupported repository hosts (like Bitbucket)
+
+There is also a test to confirm that the function succeeds when both the URL
+and token are valid. This requires a valid personal access token, and should only
+be entered into the tests locally, for local testing purposes. 
+"""
+
 
 class TestTokenValidation(unittest.TestCase):
 
@@ -32,10 +47,10 @@ class TestTokenValidation(unittest.TestCase):
         self.assertFalse(success)
         self.assertIn("URL error", message)
 
-    @unittest.skip("Requires real GitHub token")
+    @unittest.skip("Requires real GitHub token")    # Comment out this line when testing with personal access token
     def test_valid_github_token(self):
         url = "https://github.com/octocat/Hello-World"
-        token = "ghp_yourValidTokenHere"
+        token = "ghp_yourValidTokenHere"    # Replace str with personal access token
         success, message = validate_repo_and_token(url, token)
         self.assertTrue(success)
         self.assertIn("valid", message.lower())


### PR DESCRIPTION
### Summary

This pull request updates the backend to give clearer error messages when validating repository URLs and access tokens.

Error Differentiation for Token vs URL Issues:
- Updates the validation logic to distinguish between invalid access tokens and incorrect repository URLs.
- Previously, all failures defaulted to a generic "invalid token" message, even if the URL was incorrect.

New Unit Tests:
- Adds a new test module to verify expected behavior across multiple scenarios, including invalid tokens, invalid URLs, and unknown hosts.

### Details

Improved Error Messages for Repository Validation:
- Introduces a new function that:
  - First checks whether the repo host is supported (GitHub or GitLab).
  - Then separately validates the repository URL and token.
  - Returns precise error messages depending on which part fails.
- Works alongside existing utility functions

New Test Module:
- Covers the following scenarios:
  - Invalid GitHub URL
  - Valid URL but invalid token
  - Nonsensical URL input
  - Unsupported hosts (like Bitbucket)
  - A skipped test for valid token usage (for local/manual verification)

### Testing

- Verified that:
  - Invalid URLs produce URL-specific error messages.
  - Invalid tokens return token-specific errors.
  - Valid URLs and tokens (in skipped test) are accepted.
  - Errors are distinct and informative across all cases.

### Related Issues

- Closes #209

### Additional Notes

- All changes are limited to the `meta_creator/token_check.py` and `tests/test_token_check.py` files.
- Please review and let me know if further adjustments are needed.