### PR TITLE
223 fix dependabot security alerts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,5 @@ python-gitlab==3.13.0
 GitPython>=3.1.41
 
 # Git-based packages pinned to specific commits/branches
-git+https://github.com/softwarepub/hermes-plugin-github-gitlab@2a28c038bd87a3050f365ed103702554786ad66f#egg=hermes_plugin_githublab
+git+https://github.com/softwarepub/hermes-plugin-github-gitlab
 git+https://github.com/Aidajafarbigloo/hermes@14fc040afd4b7f7268b937477dce56bd7695fbf3#egg=hermes
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Core Django and JSON handling
-django==4.1.10
+Django>=4.2.22
 django_jsonforms==1.1.2
 environs==9.3.5
 marshmallow>=3.10,<3.20


### PR DESCRIPTION
This PR includes two updates to `requirement.txt`:
- Upgraded Django to solve a security alert raised by Dependabot.
- Updated the `hermes-plugin-github-gitlab` dependency by removing the pinned commit hash, so it now tracks the latest changes on the default branch.