### PR TITLE
257 hermes integration through cloning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "3.11"
 
     - name: Cache pip dependencies
       uses: actions/cache@v4
@@ -58,10 +58,10 @@ jobs:
       uses: actions/checkout@v4
 
 
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "3.11"
 
     - name: Install dependencies
       run: |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,4 +38,4 @@ test_job:
     # - echo "$CI_PERSONAL_TOKEN_KEY_GL"
     - python manage.py test tests
 
-image: python:3.10
+image: python:3.11

--- a/meta_creator/hermes_process.py
+++ b/meta_creator/hermes_process.py
@@ -5,7 +5,6 @@ import os
 from .token_handling_in_toml import update_token_to_toml, remove_token_from_toml
 from .utils import merge_people_metadata
 
-# hermes_utils.py
 
 def run_hermes_commands(url, token=None):
     errors = []
@@ -21,7 +20,7 @@ def run_hermes_commands(url, token=None):
 
     # Step 2: Run hermes harvest with the specified URL
     print("Running hermes harvest with URL...")
-    harvest_process = subprocess.run(['hermes', 'harvest', '--path', url], capture_output=True, text=True, cwd=base_directory)
+    harvest_process = subprocess.run(['hermes', 'harvest', '--url', url, '--token', token], capture_output=True, text=True, cwd=base_directory)
     
     hermes_dir = os.path.join(base_directory, ".hermes", "harvest")
     # Print harvested files
@@ -181,4 +180,3 @@ def run_hermes_commands(url, token=None):
         'errors': errors,
         'metadata': hermes_metadata_dict if hermes_metadata_dict else {}
     }
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ GitPython>=3.1.41
 
 # Git-based packages pinned to specific commits/branches
 git+https://github.com/softwarepub/hermes-plugin-github-gitlab
-git+https://github.com/Aidajafarbigloo/hermes@14fc040afd4b7f7268b937477dce56bd7695fbf3#egg=hermes
+git+https://github.com/Aidajafarbigloo/hermes.git@feature/harvesting-metadata-from-a-provided-repository-URL-via-cloning#egg=hermes
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pyyaml>=6.0
 pyld==2.0.3
 
 # Git integration libraries
-python-gitlab==3.13.0
+python-gitlab==8.4.0
 GitPython>=3.1.41
 
 # Git-based packages pinned to specific commits/branches


### PR DESCRIPTION
This pull request introduces a change in the harvesting approach.

Previously, the workflow relied on a repository path. It now clones the repository using its URL in order to extract metadata from CFF and CodeMeta files. Additionally, a GitHub/GitLab token is used through the githublab plugin to retrieve metadata directly from GitHub or GitLab based on the repository URL. As a result, the `hermes harvest` command has been updated to accept a repository URL instead of a path.

One additional point is about dependencies:
In requirements.txt, the githublab plugin is currently pinned to the main branch. During installation, this results in the main branch being installed automatically. However, the relevant updates are implemented in a [different branch](https://github.com/softwarepub/hermes-plugin-github-gitlab/tree/19-apply-some-changes-according-to-cloning-approach) within the same repository. Therefore, requirements.txt should be updated to reference the correct branch so that the installation pulls the modified version of the plugin.
